### PR TITLE
Remove warnings on Crystal 0.35.

### DIFF
--- a/src/graphlb/dot_parser/ast/block_token.cr
+++ b/src/graphlb/dot_parser/ast/block_token.cr
@@ -1,7 +1,7 @@
 require "./token.cr"
 module Dot
   module AST
-    class BlockToken < Token
+    class BlockToken < ValueToken
       getter :id, :values, :blocks
 
       alias Value = NamedTuple(
@@ -26,7 +26,7 @@ module Dot
         @blocks = blocks
       end
 
-      def value
+      def value : ValueType
         {
           id: id,
           args: args.map { |arg| arg.value },

--- a/src/graphlb/dot_parser/ast/false_token.cr
+++ b/src/graphlb/dot_parser/ast/false_token.cr
@@ -12,7 +12,7 @@ module Dot
         STRING_VAL
       end
 
-      def value
+      def value  : ValueType
         false
       end
     end

--- a/src/graphlb/dot_parser/ast/identifier_token.cr
+++ b/src/graphlb/dot_parser/ast/identifier_token.cr
@@ -9,7 +9,7 @@ module Dot
         parts: Array(Value)
       )
 
-      def value
+      def value : ValueType
         {
           id: string,
           parts: parts_value

--- a/src/graphlb/dot_parser/ast/null_token.cr
+++ b/src/graphlb/dot_parser/ast/null_token.cr
@@ -11,7 +11,7 @@ module Dot
         STRING_VAL
       end
 
-      def value
+      def value : ValueType
         nil
       end
     end

--- a/src/graphlb/dot_parser/ast/number_token.cr
+++ b/src/graphlb/dot_parser/ast/number_token.cr
@@ -8,7 +8,7 @@ module Dot
         super(peg_tuple, stripped_string)
       end
 
-      def value
+      def value : ValueType
         if string.includes?('.')
           string.to_f64
         else

--- a/src/graphlb/dot_parser/ast/string_token.cr
+++ b/src/graphlb/dot_parser/ast/string_token.cr
@@ -1,7 +1,7 @@
 module Dot
   module AST
     class StringToken < ValueToken
-      def value
+      def value : ValueType
         string
       end
     end

--- a/src/graphlb/dot_parser/ast/token.cr
+++ b/src/graphlb/dot_parser/ast/token.cr
@@ -14,8 +14,6 @@ module Dot
       def as_s
         string
       end
-
-      abstract def value
     end
   end
 end

--- a/src/graphlb/dot_parser/ast/true_token.cr
+++ b/src/graphlb/dot_parser/ast/true_token.cr
@@ -11,7 +11,7 @@ module Dot
         STRING_VAL
       end
 
-      def value
+      def value : ValueType
         true
       end
     end


### PR DESCRIPTION
There are two bellman ford tests failing. seems not related with the warnings.